### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/ola_ros/include/ola_bridge_nodelet.h
+++ b/ola_ros/include/ola_bridge_nodelet.h
@@ -47,8 +47,8 @@ namespace ola_ros {
             ola::OlaCallbackClientWrapper _client;
     };
 
-    //PLUGINLIB_EXPORT_CLASS(ola_ros::OlaBridge, nodelet::Nodelet);
-    PLUGINLIB_DECLARE_CLASS(ola_ros, OlaBridge, ola_ros::OlaBridge, nodelet::Nodelet);
+    PLUGINLIB_EXPORT_CLASS(ola_ros::OlaBridge, nodelet::Nodelet);
+    //PLUGINLIB_DECLARE_CLASS(ola_ros, OlaBridge, ola_ros::OlaBridge, nodelet::Nodelet);
 }
 
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions